### PR TITLE
Remove Library Relocation

### DIFF
--- a/server/pom.xml
+++ b/server/pom.xml
@@ -135,32 +135,6 @@
                                     </excludes>
                                 </filter>
                             </filters>
-                            <relocations>
-                                <relocation>
-                                    <pattern>jline</pattern>
-                                    <shadedPattern>org.loomdev.loom.lib.jline</shadedPattern>
-                                </relocation>
-                                <relocation>
-                                    <pattern>it.unimi</pattern>
-                                    <shadedPattern>org.loomdev.loom.lib.it.unimi</shadedPattern>
-                                </relocation>
-                                <relocation>
-                                    <pattern>org.apache.commons.codec</pattern>
-                                    <shadedPattern>org.loomdev.loom.lib.org.apache.commons.codec</shadedPattern>
-                                </relocation>
-                                <relocation>
-                                    <pattern>org.apache.commons.io</pattern>
-                                    <shadedPattern>org.loomdev.loom.lib.org.apache.commons.io</shadedPattern>
-                                </relocation>
-                                <relocation>
-                                    <pattern>org.apache.commons.lang3</pattern>
-                                    <shadedPattern>org.loomdev.loom.lib.org.apache.commons.lang3</shadedPattern>
-                                </relocation>
-                                <relocation>
-                                    <pattern>org.objectweb.asm</pattern>
-                                    <shadedPattern>org.loomdev.loom.lib.org.objectweb.asm</shadedPattern>
-                                </relocation>
-                            </relocations>
                             <transformers>
                                 <transformer implementation="org.apache.maven.plugins.shade.resource.AppendingTransformer">
                                     <resource>META-INF/services/java.sql.Driver</resource>


### PR DESCRIPTION
Removes library relocation as it just means plugins can't use those libraries.
For example, if a plugin wants to read a file:
```java
File file = new File("path/of/file");
FileUtils.readFileToString(file, StandardCharsets.UTF_8);
```
it will not work:
```
[00:00:00] [ServerThread/ERROR]: ClassNoDefFoundError: org/apache/commons/io/FileUtils
```
 I'm not entirely sure what the point of relocating libraries is, so let me know if there are any reasons.